### PR TITLE
Added low-voltage mode to assembly states

### DIFF
--- a/intera_core_msgs/msg/AssemblyState.msg
+++ b/intera_core_msgs/msg/AssemblyState.msg
@@ -2,6 +2,7 @@ bool ready               # true if enabled and ready to operate, e.g., not homin
 bool enabled             # true if enabled
 bool stopped             # true if stopped -- e-stop asserted
 bool error               # true if a component of the assembly has an error
+bool lowVoltage          # true when the robot is in low voltage mode
 #
 # The following are specific to the robot top-level assembly:
 uint8  estop_button      # One of the following:


### PR DESCRIPTION
Updates assembly states to express when low-voltage mode is applied. SDK users will likely not need to care about this mode.
