### PR TITLE
Updated JointCommand Interface for Trajectories

### DIFF
--- a/intera_core_msgs/msg/JointCommand.msg
+++ b/intera_core_msgs/msg/JointCommand.msg
@@ -1,8 +1,18 @@
-int32 mode
-float64[] command
-string[]  names
+Header header
 
+int32 mode             # Mode in which to command arm
+
+string[]  names        # Joint names order for command
+
+# Fields of commands indexed according to the Joint names vector.
+# Command fields required for a desired mode are listed in the comments
+float64[] position     # (radians)   Required for POSITION_MODE and TRAJECTORY_MODE
+float64[] velocity     # (rad/sec)   Required for VELOCITY_MODE and TRAJECTORY_MODE
+float64[] acceleration # (rad/sec^2) Required for                   TRAJECTORY_MODE
+float64[] effort       # (newtons)   Required for TORQUE_MODE
+
+# Modes available to command arm
 int32 POSITION_MODE=1
 int32 VELOCITY_MODE=2
 int32 TORQUE_MODE=3
-int32 RAW_POSITION_MODE=4
+int32 TRAJECTORY_MODE=4


### PR DESCRIPTION
`JointCommand` associated with `JointPlugin` interface update. This change moves away from a generic command field and towards individual `position`, `velocity`, `acceleration`, `effort` fields, to be updated per command mode:
- position       --> (radians)   Required for POSITION_MODE and TRAJECTORY_MODE
- velocity        --> (rad/sec)   Required for VELOCITY_MODE and TRAJECTORY_MODE
- acceleration --> (rad/sec^2) Required for                   TRAJECTORY_MODE
- effort            --> (newton-meters)   Required for TORQUE_MODE
