### PR TITLE
Adds actionlib_msgs dep and Calibration Action

### DIFF
--- a/intera_core_msgs/CMakeLists.txt
+++ b/intera_core_msgs/CMakeLists.txt
@@ -4,6 +4,7 @@ project(intera_core_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
         message_generation
+        actionlib_msgs
         std_msgs
         geometry_msgs
         sensor_msgs
@@ -61,11 +62,12 @@ add_service_files( DIRECTORY srv
         IOComponentCommandSrv.srv
 )
 
+add_action_files(DIRECTORY action FILES CalibrationCommand.action)
 
 ## Build
-generate_messages(DEPENDENCIES std_msgs geometry_msgs sensor_msgs)
+generate_messages(DEPENDENCIES std_msgs geometry_msgs sensor_msgs actionlib_msgs)
 
-catkin_package(CATKIN_DEPENDS message_runtime std_msgs geometry_msgs sensor_msgs)
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs geometry_msgs sensor_msgs actionlib_msgs)
 
 
 ## Install

--- a/intera_core_msgs/action/CalibrationCommand.action
+++ b/intera_core_msgs/action/CalibrationCommand.action
@@ -1,0 +1,24 @@
+# Engine command goal
+string command
+string CALIBRATION_START=start
+string CALIBRATION_STOP=stop
+
+---
+# result
+bool result
+string statusId
+# possible values for statusId are:
+string SUCCESS=Success
+string STOPPED=Stopped
+string GENERIC_FAILURE=calibrationFailure
+string INCOMPLETE=incomplete
+string GRIPPER_ON=cannotCalibrateWithGripper
+string TORQUES_EXCEEDED_THRESHOLD=torquesExceededThreshold
+string PLANNER_FAILURE=plannerFailure
+
+
+---
+# feedback
+string currentState
+uint32 numberOfPoses
+uint32 currentPoseNumber

--- a/intera_core_msgs/package.xml
+++ b/intera_core_msgs/package.xml
@@ -27,10 +27,12 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
This change creates an Action required for interfacing with the Calibrate Action onboard the robot.
See https://github.com/RethinkRobotics/intera_sdk/pull/46 for implementation details.
