### PR TITLE
Added 'DOWN' IO Status state to msg

### DIFF
--- a/intera_core_msgs/msg/IOStatus.msg
+++ b/intera_core_msgs/msg/IOStatus.msg
@@ -1,10 +1,12 @@
 ## IO status data
 #
 string tag             # one of the values listed below
+#   down     Inoperative, not fully instantiated
 #   ready    OK, fully operational
 #   busy     OK, not ready to output data; input data value may be stale
 #   unready  OK, not operational; data is invalid
 #   error    Error, not operational
+string DOWN      = down
 string READY     = ready
 string BUSY      = busy
 string UNREADY   = unready


### PR DESCRIPTION
Adds a new status to let the user know when an IO Device is not fully initialized.
