### PR TITLE
Add motion_msgs and additional support messages

### DIFF
--- a/intera_core_msgs/CMakeLists.txt
+++ b/intera_core_msgs/CMakeLists.txt
@@ -45,6 +45,8 @@ add_message_files( DIRECTORY msg
         IOStatus.msg
         IONodeStatus.msg
         URDFConfiguration.msg
+        InteractionControlCommand.msg
+        InteractionControlState.msg
 )
 
 add_service_files( DIRECTORY srv

--- a/intera_core_msgs/msg/InteractionControlCommand.msg
+++ b/intera_core_msgs/msg/InteractionControlCommand.msg
@@ -1,0 +1,48 @@
+# Message sets the interaction (impedance/force) control on or off
+# It also contains desired cartesian stiffness K, damping D, and force values
+
+Header header
+bool      interaction_control_active
+
+## Cartesian Impedance Control Parameters
+# Stiffness units are (N/m) for first 3 and (Nm/rad) for second 3 values
+float64[] K_impedance
+# Force certain directions to have maximum possible impedance for a given pose
+bool[] max_impedance
+# Damping units are (Ns/m) for first 3 and (Nms/rad) for the second 3 values
+float64[] D_impedance
+# Joint Nullspace stiffness units are in (Nm/rad) (length == number of joints)
+float64[] K_nullspace
+
+## Parameters for force control or impedance control with force limit
+# If in force mode, this is the vector of desired forces/torques
+# to be regulated in (N) and (Nm)
+# If in impedance with force limit mode, this vector specifies the
+# magnitude of forces/torques (N and Nm) that the command will not exceed.
+float64[] force_command
+
+## Desired frame
+geometry_msgs/Pose interaction_frame
+string endpoint_name
+# True if impedance and force commands are defined in endpoint frame
+bool in_endpoint_frame
+
+## Mode Selection Parameters
+# The possible interaction control modes are:
+# Impedance mode: implements desired endpoint stiffness and damping.
+uint8 IMPEDANCE_MODE=1
+# Force mode: applies force/torque in the specified dimensions.
+uint8 FORCE_MODE=2
+# Impedance with force limit: impedance control while ensuring the commanded
+# forces/torques do not exceed force_command.
+uint8 IMPEDANCE_WITH_FORCE_LIMIT_MODE=3
+# Force with motion bounds: force control while ensuring the current
+# pose/velocities do not exceed forceMotionThreshold (currenetly defined in yaml)
+uint8 FORCE_WITH_MOTION_LIMIT_MODE=4
+
+# Specifies the interaction control mode for each Cartesian dimension (6)
+uint8[] interaction_control_mode
+
+# All 6 values in force and impedance parameter vectors have to be filled,
+# If a control mode is not used in a Cartesian dimension,
+# the corresponding parameters will be ignored.

--- a/intera_core_msgs/msg/InteractionControlState.msg
+++ b/intera_core_msgs/msg/InteractionControlState.msg
@@ -1,0 +1,20 @@
+## InteractionControlState.msg ##
+# Internal state of the interaction controller including
+# whether the controller is active, current impedence parameters,
+# and the commanded endpoint forces by the interaction controller
+
+Header header
+
+bool      interaction_control_active
+
+## Impedance Control Parameters
+float64[] K_impedance
+float64[] D_impedance
+
+## Force Control Parameters
+# Vector of forces (wrench) (N and Nm) commanded by the interaction controller
+# for the endpoint.
+float64[] endpoint_force_command
+
+string endpoint_name
+bool in_endpoint_frame

--- a/motion_msgs/CMakeLists.txt
+++ b/motion_msgs/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(motion_msgs)
+
+find_package(catkin REQUIRED COMPONENTS actionlib_msgs message_generation std_msgs
+                                        geometry_msgs motor_control_msgs intera_core_msgs)
+
+add_message_files(DIRECTORY msg
+                  FILES
+                    MotionStatus.msg
+                    TrackingOptions.msg
+                    Trajectory.msg
+                    TrajectoryAnalysis.msg
+                    TrajectoryOptions.msg
+                    Waypoint.msg
+                    WaypointOptions.msg
+                    TrackingError.msg
+                    )
+
+add_action_files(DIRECTORY action FILES MotionCommand.action)
+
+generate_messages(DEPENDENCIES std_msgs geometry_msgs motor_control_msgs intera_core_msgs actionlib_msgs)
+
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs
+                              geometry_msgs motor_control_msgs intera_core_msgs actionlib_msgs)

--- a/motion_msgs/action/MotionCommand.action
+++ b/motion_msgs/action/MotionCommand.action
@@ -1,0 +1,21 @@
+# Engine command goal
+string command
+string MOTION_START=start
+string MOTION_STOP=stop
+string MOTION_PAUSE=pause
+string MOTION_RESUME=resume
+string MOTION_APPEND=append  # Not Yet Implemented
+motion_msgs/Trajectory trajectory
+
+---
+# result
+bool result
+string errorId
+TrajectoryAnalysis trajectory_analysis
+int32 last_successful_waypoint
+int32 HAVE_NOT_REACHED_FIRST_WAYPOINT=-1
+int32 GENERAL_TRAJECTORY_FAILURE=-2
+
+---
+# feedback
+motion_msgs/MotionStatus status

--- a/motion_msgs/msg/MotionStatus.msg
+++ b/motion_msgs/msg/MotionStatus.msg
@@ -1,0 +1,11 @@
+# motion status
+Header header
+string motion_status
+string current_trajectory
+uint32 current_waypoint
+uint32  motion_request
+
+string MOTION_STOPPED=stopped
+string MOTION_RUNNING=running
+string MOTION_ERROR=error
+string MOTION_PAUSED=paused

--- a/motion_msgs/msg/TrackingError.msg
+++ b/motion_msgs/msg/TrackingError.msg
@@ -1,0 +1,23 @@
+# This message contains data related to tracking performance at the motion controller level
+Header header
+
+# name associated with each element for the vectors in this message
+string[] joint_names
+
+# (reference position) - (measured position) in radians
+float64[] position_error
+
+# (reference velocity) - (measured velocity) in radians per second
+float64[] velocity_error
+
+# Norm of the tracking error in radians
+float64 position_error_norm
+
+# Tracking lag in seconds (command point time - time at closest point on trajectory)
+float64 tracking_time_lag
+
+# Dimensionless play-back rate. 1.0 = planned, 0.5 = half speed, 2.0 = double speed
+float64 tracking_time_rate
+
+# Id for the next waypoint that we are moving towards
+uint32 next_waypoint_id

--- a/motion_msgs/msg/TrackingOptions.msg
+++ b/motion_msgs/msg/TrackingOptions.msg
@@ -1,0 +1,14 @@
+# Minimum trajectory tracking time rate:  (default = less than one)
+motor_control_msgs/OptionalFloat min_time_rate
+
+# Maximum trajectory tracking time rate:  (1.0 = real-time = default)
+motor_control_msgs/OptionalFloat max_time_rate
+
+# How quickly to change the tracking time rate
+motor_control_msgs/OptionalFloat time_rate_accel
+
+# How close (in rad) each joint should be to the final goal
+float64[] goal_joint_tolerance
+
+# Settling time after reaching the end of the trajectory
+motor_control_msgs/OptionalFloat goal_time_tolerance

--- a/motion_msgs/msg/Trajectory.msg
+++ b/motion_msgs/msg/Trajectory.msg
@@ -1,0 +1,13 @@
+# Representation of a trajectory used by the engine and motion controller.
+
+# optional label
+string label
+
+# Array of joint names that correspond to the waypoint joint_positions
+string[] joint_names
+
+# Array of waypoints that comprise the trajectory
+motion_msgs/Waypoint[] waypoints
+
+# Trajectory level options
+motion_msgs/TrajectoryOptions trajectory_options

--- a/motion_msgs/msg/TrajectoryAnalysis.msg
+++ b/motion_msgs/msg/TrajectoryAnalysis.msg
@@ -1,0 +1,20 @@
+# The duration of the reference trajectory, as originally planned
+float64 planned_duration
+
+# The measured duration of the trajectory, as executed
+float64 measured_duration
+
+# Minimum commanded angle during trajectory for each joint
+float64[] min_angle_command
+
+# Maximum commanded angle during trajectory for each joint
+float64[] max_angle_command
+
+# Peak speed command = max(abs(reference velocity)) for each joint
+float64[] peak_speed_command
+
+# Peak accel command = max(abs(reference acceleration)) for each joint
+float64[] peak_accel_command
+
+# Peak jerk command = max(abs(reference jerk)) for each joint
+float64[] peak_jerk_command

--- a/motion_msgs/msg/TrajectoryOptions.msg
+++ b/motion_msgs/msg/TrajectoryOptions.msg
@@ -1,0 +1,35 @@
+# Trajectory interpolation type
+string CARTESIAN=CARTESIAN
+string JOINT=JOINT
+string interpolation_type
+
+# True if the trajectory uses interaction control, false for position control.
+bool interaction_control
+
+# Interaction control parameters
+intera_core_msgs/InteractionControlCommand interaction_params
+
+# Allow small joint adjustments at the beginning of Cartesian trajectories.
+# Set to false for 'small' motions.
+bool nso_start_offset_allowed
+
+# Check the offset at the end of a Cartesian trajectory from the final waypoint nullspace goal.
+bool nso_check_end_offset
+
+# Options for the tracking controller:
+TrackingOptions tracking_options
+
+# Desired trajectory end time, ROS timestamp
+time end_time
+
+# Low-level trajectory architechture (optional, leave blank to use default values)
+# See KinematicTrajectory::KinematicTrajectoryArchitecture
+string DEFAULT=DEFAULT
+string CUBIC_HERMITE=CUBIC_HERMITE
+string CLAMPED_CUBIC=CLAMPED_CUBIC
+string CLAMPED_BOUNDARY_CUBIC=CLAMPED_BOUNDARY_CUBIC
+string CONSTRAINED_CLAMPED_CUBIC=CONSTRAINED_CLAMPED_CUBIC
+string CONSTRAINED_BOUNDARY_CUBIC=CONSTRAINED_BOUNDARY_CUBIC
+string CONSTRAINED_COMPOSITE_CUBIC=CONSTRAINED_COMPOSITE_CUBIC
+string QUINTIC_HERMITE=QUINTIC_HERMITE
+string trajectory_architecture_type

--- a/motion_msgs/msg/Waypoint.msg
+++ b/motion_msgs/msg/Waypoint.msg
@@ -1,0 +1,15 @@
+# Representation of a waypoint used by the motion controller
+
+# Desired joint positions
+float64[] joint_positions
+
+# Name of the endpoint that is currently active
+string active_endpoint
+
+# Cartesian pose
+# This is not used in trajectories using joint interpolation
+geometry_msgs/PoseStamped pose
+
+# Waypoint specific options
+# Default values will be used if not set
+motion_msgs/WaypointOptions options

--- a/motion_msgs/msg/WaypointOptions.msg
+++ b/motion_msgs/msg/WaypointOptions.msg
@@ -1,0 +1,23 @@
+# Ratio of max allowed joint speed : max planned joint speed (from 0.0 to 1.0)
+float64 max_joint_speed_ratio
+
+# Joint tracking tolerances before slowdown heuristic is used. In radians.
+float64[] joint_tolerances
+
+# Maximum linear speed of endpoint (for cartesian paths). m/s.
+float64 max_linear_speed
+
+# Maximum linear acceleration of endpoint (for cartesian paths). m/s^2.
+float64 max_linear_accel
+
+# Maximum rotational speed of endpoint (for cartesian paths). rad/s.
+float64 max_rotational_speed
+
+# Maximum rotational acceleration of endpoint (for cartesian paths). rad/s^2.
+float64 max_rotational_accel
+
+# Maximum accelerations for each joint, for joint paths. rad/s^2.
+float64[] max_joint_accel
+
+# Optional waypoint label
+string label

--- a/motion_msgs/package.xml
+++ b/motion_msgs/package.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <package>
-  <name>intera_common</name>
+  <name>motion_msgs</name>
   <version>5.1.0</version>
   <description>
-    Common metapackage for Intera messages, and end effector URDF's
-    and meshes for the Intera robots from Rethink Robotics.
+    Intera Motion messages
   </description>
 
   <maintainer email="rsdk.support@rethinkrobotics.com">
@@ -22,12 +21,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- package contains messages -->
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>intera_core_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>motor_control_msgs</build_depend>
+
+  <run_depend>message_runtime</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>intera_core_msgs</run_depend>
-  <run_depend>intera_tools_description</run_depend>
-  <run_depend>motion_msgs</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
   <run_depend>motor_control_msgs</run_depend>
-  <export>
-    <metapackage/>
-  </export>
 
 </package>

--- a/motor_control_msgs/CMakeLists.txt
+++ b/motor_control_msgs/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(motor_control_msgs)
+
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+
+add_message_files(DIRECTORY msg
+                  FILES
+                    OptionalFloat.msg
+  )
+
+
+generate_messages(DEPENDENCIES std_msgs)
+
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs)

--- a/motor_control_msgs/msg/OptionalFloat.msg
+++ b/motor_control_msgs/msg/OptionalFloat.msg
@@ -1,0 +1,3 @@
+# this value is only used if the flag is set
+bool set
+float64 value

--- a/motor_control_msgs/package.xml
+++ b/motor_control_msgs/package.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0"?>
 <package>
-  <name>intera_common</name>
+  <name>motor_control_msgs</name>
   <version>5.1.0</version>
   <description>
-    Common metapackage for Intera messages, and end effector URDF's
-    and meshes for the Intera robots from Rethink Robotics.
+  Motor Control messages. Will be removed in 5.2
   </description>
-
+  
   <maintainer email="rsdk.support@rethinkrobotics.com">
     Rethink Robotics Inc.
   </maintainer>
@@ -21,13 +20,12 @@
   <author>Rethink Robotics Inc.</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <run_depend>intera_core_msgs</run_depend>
-  <run_depend>intera_tools_description</run_depend>
-  <run_depend>motion_msgs</run_depend>
-  <run_depend>motor_control_msgs</run_depend>
-  <export>
-    <metapackage/>
-  </export>
-
+ 
+  <!-- package contains messages -->
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+ 
+  <run_depend>message_runtime</run_depend>
+  <run_depend>std_msgs</run_depend>
+  
 </package>


### PR DESCRIPTION
This is the initial commit for the message API to the motion controller. This is set up to work with Intera 5.1. In 5.2, we will rename motion_msgs to be less generic and move OptionalFloat.msg.