### PR TITLE
fixed bug in none fingertip

### DIFF
--- a/intera_tools_description/urdf/electric_gripper/fingers/none.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/none.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="none_tip">
-  <xacro:macro name="finger_tip_xacro" params="parent_link reflect *joint_origin">
+  <xacro:macro name="finger_tip_xacro" params="parent_link grip reflect *joint_origin">
     <link name="${parent_link}_tip">
     </link>
 


### PR DESCRIPTION
"none" gripper tips are supported by the electric gripper xacro, but did not account for the "grip" side (likely because the value doesn't have an effect on anything). This adds the parameter to prevent xacro from failing.