### PR TITLE
Update EPG xacro structure and remove per-link inertia

### DIFF
--- a/intera_tools_description/urdf/connector_plate/connector_plate.xacro
+++ b/intera_tools_description/urdf/connector_plate/connector_plate.xacro
@@ -4,8 +4,8 @@
   <xacro:property name="rethink_connector_plate_length" value="0.0151" scope="global"/>
   <link name="${side}_connector_plate_base">
     <inertial>
-      <origin xyz="-0.00032768 -2.5612E-05 0.0062193" rpy="0 0 0" />
-      <mass value="0.1609" />
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="0.0" />
       <inertia ixx="6.9922E-05"  ixy="6.1026E-08"  ixz="-1.7042E-06"
                iyy="6.8188E-05"  iyz="-1.6118E-08" izz="0.00012392" />
     </inertial>
@@ -34,7 +34,7 @@
     </gazebo>
   </xacro:if>
   <link name="${side}_connector_plate_mount" />
-  <joint name="${side}_connector_plate_base_joint" type="fixed">
+  <joint name="${side}_connector_plate_mount_joint" type="fixed">
     <origin xyz="0 0 ${rethink_connector_plate_length+0.0025}" rpy="0 0 0" />
     <parent link="${side}_connector_plate_base"  />
     <child  link="${side}_connector_plate_mount" />

--- a/intera_tools_description/urdf/electric_gripper/fingers/basic_hard_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/basic_hard_tip.xacro
@@ -19,8 +19,8 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
-        <mass value="0.01"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>

--- a/intera_tools_description/urdf/electric_gripper/fingers/basic_hard_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/basic_hard_tip.xacro
@@ -19,9 +19,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/basic_soft_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/basic_soft_tip.xacro
@@ -19,8 +19,8 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
-        <mass value="0.01"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>

--- a/intera_tools_description/urdf/electric_gripper/fingers/basic_soft_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/basic_soft_tip.xacro
@@ -19,9 +19,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/extended_narrow.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/extended_narrow.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="extended_narrow">
-  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp">
+  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp gazebo">
   <xacro:property name="finger_length" value="0.1127" scope="global"/>
   <xacro:property name="finger_width" value="0.01725" scope="local"/>
     <link name="${gripper_side}_gripper_${finger_side}_finger">
@@ -29,28 +29,30 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
-        <mass value="0.02"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>
 
-    <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
-      <mu1>1000</mu1>
-      <mu2>1000</mu2>
-      <fdir1>0.0 0.0 1.0</fdir1>
-      <kp>1e5</kp>
-      <kd>1.0</kd>
-    </gazebo>
+    <xacro:if value="${gazebo}">
+      <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
+        <mu1>1000</mu1>
+        <mu2>1000</mu2>
+        <fdir1>0.0 0.0 1.0</fdir1>
+        <kp>1e5</kp>
+        <kd>1.0</kd>
+      </gazebo>
+    </xacro:if>
 
-   <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
-   <xacro:if value="${finger_tip in none}">
-     <xacro:property name="finger_tip" value="none" scope="local"/>
-   </xacro:if>
-   <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
-   <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
-       <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
-   </xacro:finger_tip_xacro>
+    <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
+    <xacro:if value="${finger_tip in none}">
+      <xacro:property name="finger_tip" value="none" scope="local"/>
+    </xacro:if>
+    <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
+    <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
+        <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
+    </xacro:finger_tip_xacro>
 
   </xacro:macro>
 </robot>

--- a/intera_tools_description/urdf/electric_gripper/fingers/extended_narrow.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/extended_narrow.xacro
@@ -29,9 +29,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/extended_wide.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/extended_wide.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="wide_extended">
-  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp">
+  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp gazebo">
     <xacro:property name="finger_length" value="0.1127" scope="global"/>
     <xacro:property name="finger_width" value="0.05503" scope="local"/>
     <link name="${gripper_side}_gripper_${finger_side}_finger">
@@ -29,28 +29,30 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
-        <mass value="0.02"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>
 
-    <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
-      <mu1>1000</mu1>
-      <mu2>1000</mu2>
-      <fdir1>0.0 0.0 1.0</fdir1>
-      <kp>1e5</kp>
-      <kd>1.0</kd>
-    </gazebo>
+    <xacro:if value="${gazebo}">
+      <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
+        <mu1>1000</mu1>
+        <mu2>1000</mu2>
+        <fdir1>0.0 0.0 1.0</fdir1>
+        <kp>1e5</kp>
+        <kd>1.0</kd>
+      </gazebo>
+    </xacro:if>
 
-   <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
-   <xacro:if value="${finger_tip in none}">
-     <xacro:property name="finger_tip" value="none" scope="local"/>
-   </xacro:if>
-   <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
-   <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
-       <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
-   </xacro:finger_tip_xacro>
+    <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
+    <xacro:if value="${finger_tip in none}">
+      <xacro:property name="finger_tip" value="none" scope="local"/>
+    </xacro:if>
+    <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
+    <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
+        <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
+    </xacro:finger_tip_xacro>
 
   </xacro:macro>
 </robot>

--- a/intera_tools_description/urdf/electric_gripper/fingers/extended_wide.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/extended_wide.xacro
@@ -29,9 +29,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/half_round_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/half_round_tip.xacro
@@ -19,8 +19,8 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
-        <mass value="0.01"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>

--- a/intera_tools_description/urdf/electric_gripper/fingers/half_round_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/half_round_tip.xacro
@@ -19,9 +19,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/paddle_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/paddle_tip.xacro
@@ -19,8 +19,8 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
-        <mass value="0.01"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>

--- a/intera_tools_description/urdf/electric_gripper/fingers/paddle_tip.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/paddle_tip.xacro
@@ -19,9 +19,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${pi*(g_reflect+1)/2}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/standard_narrow.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/standard_narrow.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="standard_narrow">
-  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp">
+  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp gazebo">
   <xacro:property name="finger_length" value="0.075" scope="global"/>
   <xacro:property name="finger_width" value="0.01725" scope="local"/>
     <link name="${gripper_side}_gripper_${finger_side}_finger">
@@ -29,28 +29,30 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
-        <mass value="0.02"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>
 
-    <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
-      <mu1>1000</mu1>
-      <mu2>1000</mu2>
-      <fdir1>0.0 0.0 1.0</fdir1>
-      <kp>1e5</kp>
-      <kd>1.0</kd>
-    </gazebo>
+    <xacro:if value="${gazebo}">
+      <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
+        <mu1>1000</mu1>
+        <mu2>1000</mu2>
+        <fdir1>0.0 0.0 1.0</fdir1>
+        <kp>1e5</kp>
+        <kd>1.0</kd>
+      </gazebo>
+    </xacro:if>
 
-   <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
-   <xacro:if value="${finger_tip in none}">
-     <xacro:property name="finger_tip" value="none" scope="local"/>
-   </xacro:if>
-   <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
-   <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
-       <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
-   </xacro:finger_tip_xacro>
+    <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
+    <xacro:if value="${finger_tip in none}">
+      <xacro:property name="finger_tip" value="none" scope="local"/>
+    </xacro:if>
+    <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
+    <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
+        <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
+    </xacro:finger_tip_xacro>
 
   </xacro:macro>
 </robot>

--- a/intera_tools_description/urdf/electric_gripper/fingers/standard_narrow.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/standard_narrow.xacro
@@ -29,9 +29,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/fingers/standard_wide.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/standard_wide.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="standard_wide">
-  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp">
+  <xacro:macro name="finger_xacro" params="gripper_side finger_side reflect finger_tip finger_grasp gazebo">
   <xacro:property name="finger_length" value="0.075" scope="global"/>
   <xacro:property name="finger_width" value="0.05503" scope="local"/>
     <link name="${gripper_side}_gripper_${finger_side}_finger">
@@ -29,28 +29,30 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
-        <mass value="0.02"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <mass value="0.0"/>
         <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
       </inertial>
     </link>
 
-    <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
-      <mu1>1000</mu1>
-      <mu2>1000</mu2>
-      <fdir1>0.0 0.0 1.0</fdir1>
-      <kp>1e5</kp>
-      <kd>1.0</kd>
-    </gazebo>
+    <xacro:if value="${gazebo}">
+      <gazebo reference="${gripper_side}_gripper_${finger_side}_finger">
+        <mu1>1000</mu1>
+        <mu2>1000</mu2>
+        <fdir1>0.0 0.0 1.0</fdir1>
+        <kp>1e5</kp>
+        <kd>1.0</kd>
+      </gazebo>
+    </xacro:if>
 
-   <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
-   <xacro:if value="${finger_tip in none}">
-     <xacro:property name="finger_tip" value="none" scope="local"/>
-   </xacro:if>
-   <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
-   <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
-       <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
-   </xacro:finger_tip_xacro>
+    <xacro:property name="none" value="[none, false, null, empty]" scope="local"/>
+    <xacro:if value="${finger_tip in none}">
+      <xacro:property name="finger_tip" value="none" scope="local"/>
+    </xacro:if>
+    <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${finger_tip}.xacro" />
+    <xacro:finger_tip_xacro parent_link="${gripper_side}_gripper_${finger_side}_finger" reflect="${reflect}" grasp="${finger_grasp}">
+        <origin rpy="0 0 0" xyz="0.0 ${reflect*finger_width} ${finger_length}"/>
+    </xacro:finger_tip_xacro>
 
   </xacro:macro>
 </robot>

--- a/intera_tools_description/urdf/electric_gripper/fingers/standard_wide.xacro
+++ b/intera_tools_description/urdf/electric_gripper/fingers/standard_wide.xacro
@@ -29,9 +29,9 @@
         </geometry>
       </collision>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0"/>
-        <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+        <origin rpy="0 0 ${-pi/2*(reflect+1)}" xyz="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 

--- a/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
+++ b/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
@@ -1,14 +1,15 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="rethink_electric_gripper">
   <xacro:macro name="rethink_electric_gripper" params="side r_finger r_finger_slot r_finger_tip r_finger_grasp l_finger l_finger_slot l_finger_tip l_finger_grasp use_connector_plate gazebo">
-    <xacro:property name="gripper_side" value="${side[0]}" scope="local"/>
+    <xacro:property name="gripper_side" value="${side}" scope="local"/>
 
-    <!-- Base of end effector -->
+    <!-- Base of whole end effector - (Connector Plate + Electric Gripper + Fingers + Tips) -->
     <link name="${side}_gripper_base">
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0001"/>
-        <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0.0"/>
+        <!-- Sum Gripper Mass - for whole end effector, measured from end of plastic cuff -->
+        <mass value="0.44"/>
+        <origin rpy="0 0 0" xyz="0.0028 -0.0004 0.0322"/>
+        <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
       </inertial>
     </link>
 
@@ -31,9 +32,8 @@
       </collision>
       <inertial>
         <origin rpy="${-pi/2} ${pi} 0" xyz="0.0 0.0 0.0"/>
-        <!-- gripper_base mass -->
-        <mass value="0.3"/>
-        <inertia ixx="2e-08" ixy="0" ixz="0" iyy="3e-08" iyz="0" izz="2e-08"/>
+        <mass value="0.0"/>
+        <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
       </inertial>
     </link>
 
@@ -43,8 +43,8 @@
    </xacro:unless>
    <xacro:if value="${use_connector_plate}">
      <!-- Connector Plate Joint -->
-     <joint name="${side}_connector_plate_joint" type="fixed">
-       <origin xyz="0 0 -0.0032" rpy="0 0 0" />
+     <joint name="${side}_connector_plate_base_joint" type="fixed">
+       <origin xyz="0 0 0.0018" rpy="0 0 0" />
        <parent link="${side}_gripper_base"  />
        <child  link="${side}_connector_plate_base" />
      </joint>
@@ -54,8 +54,9 @@
      <xacro:property name="electric_gripper_parent_link" value="${side}_connector_plate_mount" scope="local"/>
      <xacro:property name="connector_plate_length" value="${rethink_connector_plate_length}" scope="local"/>
    </xacro:if>
+
    <!-- Electric Gripper Base joint -->
-    <joint name="${side}_electric_gripper_base_jnt" type="fixed">
+    <joint name="${side}_electric_gripper_base_joint" type="fixed">
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <parent link="${electric_gripper_parent_link}"/>
       <child link="${side}_electric_gripper_base"/>
@@ -64,38 +65,54 @@
     <!-- Left finger link -->
     <xacro:property name="finger_length" value="0.0" scope="global"/>
     <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${l_finger}.xacro" />
-    <xacro:finger_xacro gripper_side="${gripper_side}" finger_side="l" reflect="1" finger_tip="${l_finger_tip}" finger_grasp="${l_finger_grasp}"/>
+    <xacro:finger_xacro gripper_side="${gripper_side}" finger_side="l" reflect="1" finger_tip="${l_finger_tip}" finger_grasp="${l_finger_grasp}" gazebo="${gazebo}"/>
     <xacro:property name="tip_finger_length" value="${finger_length}" scope="local"/>
 
     <!-- Right finger link -->
     <xacro:include filename="$(find intera_tools_description)/urdf/electric_gripper/fingers/${r_finger}.xacro" />
-    <xacro:finger_xacro gripper_side="${gripper_side}" finger_side="r" reflect="-1" finger_tip="${r_finger_tip}" finger_grasp="${r_finger_grasp}"/>
+    <xacro:finger_xacro gripper_side="${gripper_side}" finger_side="r" reflect="-1" finger_tip="${r_finger_tip}" finger_grasp="${r_finger_grasp}" gazebo="${gazebo}"/>
     <xacro:if value="${finger_length > tip_finger_length}">
         <xacro:property name="tip_finger_length" value="${finger_length}" scope="local"/>
     </xacro:if>
 
     <!-- Gripper Base Joint -->
-    <joint name="${side}_gripper_base" type="fixed">
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+    <xacro:property name="end_of_arm_offset" value="-0.005" scope="local"/>
+    <joint name="${side}_gripper_base_joint" type="fixed">
+      <origin rpy="0 0 0" xyz="0 0 ${end_of_arm_offset}"/>
       <parent link="${side}_hand"/>
       <child link="${side}_gripper_base"/>
     </joint>
 
     <!-- Gripper Tip joint -->
-   <xacro:property name="electric_gripper_base_length" value="0.04552" scope="local"/>
-    <joint name="${side}_endpoint" type="fixed">
-      <origin rpy="0 0 0" xyz="0 0 ${connector_plate_length+electric_gripper_base_length+tip_finger_length}"/>
+    <xacro:property name="electric_gripper_base_length" value="0.04552" scope="local"/>
+    <joint name="${side}_gripper_tip_joint" type="fixed">
+      <origin rpy="0 0 0" xyz="0 0 ${(-1*end_of_arm_offset)+connector_plate_length+electric_gripper_base_length+tip_finger_length}"/>
       <parent link="${side}_gripper_base"/>
-      <child link="${side}_gripper"/>
+      <child link="${side}_gripper_tip"/>
     </joint>
 
     <!-- Electric Gripper Tip link -->
-    <link name="${side}_gripper">
+    <link name="${side}_gripper_tip">
       <inertial>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <mass value="0.0001"/>
         <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0.0"/>
       </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.015 0.015 0.015"/>
+        </geometry>
+        <material name="darkgrey">
+          <color rgba="0.2 0.3 0.3 1" />
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <box size="0.01 0.01 0.01"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- Left finger -->

--- a/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
+++ b/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
@@ -7,8 +7,8 @@
     <link name="${side}_gripper_base">
       <inertial>
         <!-- Sum Gripper Mass - for whole end effector, measured from end of plastic cuff -->
-        <mass value="0.44"/>
-        <origin rpy="0 0 0" xyz="0.0028 -0.0004 0.0322"/>
+        <mass value="0.47"/>
+        <origin rpy="0 0 0" xyz="0.0028 -0.0004 0.0343"/>
         <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
       </inertial>
     </link>

--- a/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
+++ b/intera_tools_description/urdf/electric_gripper/rethink_electric_gripper.xacro
@@ -32,8 +32,8 @@
       </collision>
       <inertial>
         <origin rpy="${-pi/2} ${pi} 0" xyz="0.0 0.0 0.0"/>
-        <mass value="0.0"/>
-        <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
     </link>
 
@@ -94,25 +94,10 @@
     <!-- Electric Gripper Tip link -->
     <link name="${side}_gripper_tip">
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <mass value="0.0001"/>
-        <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0.0"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="2e-06"/>
+        <inertia ixx="1.1e-09" ixy="0" ixz="0" iyy="1.1e-09" iyz="0" izz="1.1e-09"/>
       </inertial>
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.015 0.015 0.015"/>
-        </geometry>
-        <material name="darkgrey">
-          <color rgba="0.2 0.3 0.3 1" />
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.01 0.01 0.01"/>
-        </geometry>
-      </collision>
     </link>
 
     <!-- Left finger -->


### PR DESCRIPTION
Synchronizes the structure and naming of the EPG xacro w/ upstream. Also remove the per-links masses and inertia (for now). Includes:

* Remove mass from all links except base link
  - Per-link mass *will* work for custom reconfigure, but will not work in Tool Editor
    (uses simplified Mass, CoM representation)
* Adjust base-joint offsets by -0.005 m
  - Allows users to measure from edge of plastic cuff, when gripper is attached
  - Compensate for offset in direct children joints
* Rename joints, links
* Add 'if gazebo' clause/param to finger xacros