### PR TITLE
Make interaction control more transparent for SDK

### DIFF
--- a/intera_core_msgs/msg/InteractionControlCommand.msg
+++ b/intera_core_msgs/msg/InteractionControlCommand.msg
@@ -27,6 +27,17 @@ string endpoint_name
 # True if impedance and force commands are defined in endpoint frame
 bool in_endpoint_frame
 
+# Set to true to disable damping during force control. Damping is used
+# to slow down robot motion during force control in free space.
+# Option included for SDK users to disable damping in force control
+bool disable_damping_in_force_control
+
+# Set to true to disable reference resetting. Reference resetting is
+# used when interaction parameters change, in order to avoid jumps/jerks.
+# Option included for SDK users to disable reference resetting if the
+# intention is to change interaction parameters.
+bool disable_reference_resetting
+
 ## Mode Selection Parameters
 # The possible interaction control modes are:
 # Impedance mode: implements desired endpoint stiffness and damping.

--- a/intera_core_msgs/msg/InteractionControlState.msg
+++ b/intera_core_msgs/msg/InteractionControlState.msg
@@ -18,3 +18,5 @@ float64[] endpoint_force_command
 
 string endpoint_name
 bool in_endpoint_frame
+bool disable_damping_in_force_control
+bool disable_reference_resetting


### PR DESCRIPTION
    Make interaction control more transparent for SDK
    
    This commit introduces two options that will
    make interaction control more transparent:
    
    1. Allow users to disable damping in the force mode.
    2. Allow users to remove reference resetting.