### PR TITLE
Allow for arbitrary rotations for constrained zero-G

### DIFF
--- a/intera_core_msgs/msg/InteractionControlCommand.msg
+++ b/intera_core_msgs/msg/InteractionControlCommand.msg
@@ -57,3 +57,10 @@ uint8[] interaction_control_mode
 # All 6 values in force and impedance parameter vectors have to be filled,
 # If a control mode is not used in a Cartesian dimension,
 # the corresponding parameters will be ignored.
+
+## Parameters for Constrained Zero-G Behaviors
+# Allow arbitrary rotational displacements from the current orientation for constrained zero-G
+# by setting rotations_for_constrained_zeroG = true. Doing this will disable the rotational
+# stiffness field which limits rotational displacements to +/- 82.5 degree.
+# NOTE: it can be used only with a stationary reference orientation
+bool rotations_for_constrained_zeroG

--- a/intera_core_msgs/msg/InteractionControlCommand.msg
+++ b/intera_core_msgs/msg/InteractionControlCommand.msg
@@ -59,8 +59,9 @@ uint8[] interaction_control_mode
 # the corresponding parameters will be ignored.
 
 ## Parameters for Constrained Zero-G Behaviors
-# Allow arbitrary rotational displacements from the current orientation for constrained zero-G
-# by setting rotations_for_constrained_zeroG = true. Doing this will disable the rotational
-# stiffness field which limits rotational displacements to +/- 82.5 degree.
-# NOTE: it can be used only with a stationary reference orientation
+# Allow for arbitrary rotational displacements from the current orientation
+# for constrained zero-G. Setting 'rotations_for_constrained_zeroG = True'
+# will disable the rotational stiffness field which limits rotational
+# displacements to +/- 82.5 degree.
+# NOTE: it will be only enabled for a stationary reference orientation
 bool rotations_for_constrained_zeroG

--- a/intera_core_msgs/msg/InteractionControlState.msg
+++ b/intera_core_msgs/msg/InteractionControlState.msg
@@ -20,3 +20,7 @@ string endpoint_name
 bool in_endpoint_frame
 bool disable_damping_in_force_control
 bool disable_reference_resetting
+
+## Parameters for Constrained Zero-G Behaviors
+# Please refer to InteractionControlCommand.msg for more details
+bool rotations_for_constrained_zeroG


### PR DESCRIPTION
This update provides a new option for interaction control
which will allow for arbitrary rotations during constrained zero-G.

A boolean (rotations_for_constrained_zeroG) has been added to
interaction control command and this can be set True while the
commanded orientation is stationary. The actual orientation is
then allowed to change without any limits (only limited by the
joint position limits) with specified rotational stiffness.
For constrained zero-G applications where the stiffnesses for
translations and/or rotations along/about some axes are zero,
setting rotations_for_constrained_zeroG = True will provide
a greater flexibility with stabler behavior. Note that when
it is set to False, the range of rotations is limited to +/-
82 degree.